### PR TITLE
EC2026: emit one Google Sheets row per jump

### DIFF
--- a/payment/ec2026RequestHandler.php
+++ b/payment/ec2026RequestHandler.php
@@ -116,26 +116,31 @@ if ($amount <= 0) {
     
     $ageProofLink = !empty($ageProofPath) ? "https://hprc.in/payment/view_proof.php?file=" . urlencode(basename($ageProofPath)) : "";
 
-    // Prepare an array of webhook payloads (one per event)
+    // Prepare an array of webhook payloads (one per jump)
     $webhookPayloads = [];
     foreach ($selectedIds as $id) {
         $category = isset($eventMapping[$id]) ? $eventMapping[$id] : "Event #$id";
         $horses = isset($horseData[$id]) ? (is_array($horseData[$id]) ? $horseData[$id] : [$horseData[$id]]) : ["N/A"];
-        
-        $webhookPayloads[] = array(
-            "name" => $name, 
-            "dob" => $dob,
-            "parentName" => $parentName, 
-            "address" => $address,
-            "mobile" => $mobile, "email" => $email, "emergencyContact" => $emergencyContact,
-            "emergencyRelation" => $emergencyRelation, "clubName" => $clubName,
-            "events" => $category, 
-            "eventHorses" => implode(", ", $horses),
-            "stablingType" => $stablingType, "stablingCount" => $stablingCount,
-            "stablingFrom" => $stablingFrom, "stablingTo" => $stablingTo,
-            "amount" => "0 (COMP)", "tracking_id" => "HPRCCHEAT1-" . $id,
-            "ageProofLink" => $ageProofLink
-        );
+
+        foreach ($horses as $jumpIdx => $horse) {
+            $jumpNumber = $jumpIdx + 1;
+            $jumpLabel = (count($horses) > 1) ? " - Jump $jumpNumber" : "";
+
+            $webhookPayloads[] = array(
+                "name" => $name,
+                "dob" => $dob,
+                "parentName" => $parentName,
+                "address" => $address,
+                "mobile" => $mobile, "email" => $email, "emergencyContact" => $emergencyContact,
+                "emergencyRelation" => $emergencyRelation, "clubName" => $clubName,
+                "events" => $category . $jumpLabel,
+                "eventHorses" => $horse,
+                "stablingType" => $stablingType, "stablingCount" => $stablingCount,
+                "stablingFrom" => $stablingFrom, "stablingTo" => $stablingTo,
+                "amount" => "0 (COMP)", "tracking_id" => "HPRCCHEAT1-" . $id . "-J" . $jumpNumber,
+                "ageProofLink" => $ageProofLink
+            );
+        }
     }
 
     // For backward compatibility or other logic, keeping these for emails

--- a/payment/ec2026ResponseHandler.php
+++ b/payment/ec2026ResponseHandler.php
@@ -143,36 +143,43 @@ if ($order_id) {
                 foreach ($selectedIds as $id) {
                     $category = isset($eventMapping[$id]) ? $eventMapping[$id] : "Event #$id";
                     $horses = isset($horseData[$id]) ? (is_array($horseData[$id]) ? $horseData[$id] : [$horseData[$id]]) : ["N/A"];
+                    $base = isset($baseFees[$id]) ? $baseFees[$id] : 2000;
+                    $perJumpFee = $base + $surcharge;
 
-                    // Bundle stabling into the first event row
-                    $displayAmount = $calculatedFees[$id];
-                    if ($isFirstRow) {
-                        $displayAmount += $stablingBalance;
-                        $isFirstRow = false;
+                    foreach ($horses as $jumpIdx => $horse) {
+                        // Bundle stabling into the very first jump row
+                        $displayAmount = $perJumpFee;
+                        if ($isFirstRow) {
+                            $displayAmount += $stablingBalance;
+                            $isFirstRow = false;
+                        }
+
+                        $jumpNumber = $jumpIdx + 1;
+                        $jumpLabel = (count($horses) > 1) ? " - Jump $jumpNumber" : "";
+
+                        $webhookData = array(
+                            "name" => $row['name'],
+                            "dob" => $row['dob'],
+                            "parentName" => $row['parentName'],
+                            "address" => $row['address'], "mobile" => $row['mobile'], "email" => $row['email'],
+                            "emergencyContact" => $row['emergencyContact'], "emergencyRelation" => $row['emergencyRelation'],
+                            "clubName" => $row['clubName'],
+                            "events" => $category . $jumpLabel,
+                            "eventHorses" => $horse,
+                            "stablingType" => $row['stablingType'],
+                            "stablingCount" => $row['stablingCount'], "stablingFrom" => $row['stablingFrom'],
+                            "stablingTo" => $row['stablingTo'], "ageProofLink" => $ageProofLink,
+                            "amount" => $displayAmount, "tracking_id" => $tracking_id . " (#$id-J$jumpNumber)"
+                        );
+
+                        $ch = curl_init($webhook_url);
+                        curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($webhookData));
+                        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:application/json'));
+                        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+                        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+                        curl_exec($ch);
+                        curl_close($ch);
                     }
-
-                    $webhookData = array(
-                        "name" => $row['name'], 
-                        "dob" => $row['dob'], 
-                        "parentName" => $row['parentName'],
-                        "address" => $row['address'], "mobile" => $row['mobile'], "email" => $row['email'],
-                        "emergencyContact" => $row['emergencyContact'], "emergencyRelation" => $row['emergencyRelation'],
-                        "clubName" => $row['clubName'], 
-                        "events" => $category,
-                        "eventHorses" => implode(", ", $horses), 
-                        "stablingType" => $row['stablingType'],
-                        "stablingCount" => $row['stablingCount'], "stablingFrom" => $row['stablingFrom'],
-                        "stablingTo" => $row['stablingTo'], "ageProofLink" => $ageProofLink,
-                        "amount" => $displayAmount, "tracking_id" => $tracking_id . " (#$id)"
-                    );
-                    
-                    $ch = curl_init($webhook_url);
-                    curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($webhookData));
-                    curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type:application/json'));
-                    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-                    curl_exec($ch); 
-                    curl_close($ch);
                 }
 
             }


### PR DESCRIPTION
Previously the Sheets webhook fired once per selected event with multi-jump horse names joined by ", " and the amount multiplied by jump count. Now each jump is its own row with a single horse name, a "- Jump N" suffix on multi-jump events, and a per-jump amount. Stabling balance still bundles into the very first row only. Tracking IDs now carry a "-J<n>" suffix for uniqueness. Applied to both the CCAvenue success path and the complimentary cheat-code path so they stay consistent.